### PR TITLE
[BUGFIX] do not support self reviews

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,7 +22,7 @@ Metrics/BlockLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 102
+  Max: 110
 
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https

--- a/app/review/pull_request.rb
+++ b/app/review/pull_request.rb
@@ -89,6 +89,10 @@ module Review
       end
 
       resource :submit do
+        before do
+          error!('Self reviews not allowed') if review_submitter == pull_request_submitter
+        end
+
         desc 'notify that a user has approved a PR'
         params do
           requires :pull_request, type: Hash do

--- a/spec/review/pull_request_spec.rb
+++ b/spec/review/pull_request_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Review::PullRequest do
             user: { login: 'Jared-Prime' } },
           review: {
             body: 'good job!',
-            user: { login: 'Jared-Prime' }
+            user: { login: 'a friend' }
           } }
       end
 
@@ -71,7 +71,7 @@ RSpec.describe Review::PullRequest do
         post '/pr/review/submit', params
 
         expect(JSON.parse(last_response.body)).to include(
-          'contents' => "Jared has reviewed github.com/Jared-Prime/review/pulls/1 by Jared \n good job!"
+          'contents' => "a friend has reviewed github.com/Jared-Prime/review/pulls/1 by Jared \n good job!"
         )
       end
     end
@@ -84,7 +84,7 @@ RSpec.describe Review::PullRequest do
           review: {
             state: 'approved',
             body: 'good job!',
-            user: { login: 'Jared-Prime' }
+            user: { login: 'a friend' }
           } }
       end
 
@@ -92,7 +92,7 @@ RSpec.describe Review::PullRequest do
         post '/pr/review/submit', params
 
         expect(JSON.parse(last_response.body)).to include(
-          'contents' => "Jared has approved github.com/Jared-Prime/review/pulls/1 by Jared \n good job!"
+          'contents' => "a friend has approved github.com/Jared-Prime/review/pulls/1 by Jared \n good job!"
         )
       end
     end
@@ -105,7 +105,7 @@ RSpec.describe Review::PullRequest do
           review: {
             state: 'changes_requested',
             body: 'good job!',
-            user: { login: 'Jared-Prime' }
+            user: { login: 'a friend' }
           } }
       end
 
@@ -113,7 +113,7 @@ RSpec.describe Review::PullRequest do
         post '/pr/review/submit', params
 
         expect(JSON.parse(last_response.body)).to include(
-          'contents' => "Jared has requested changes on github.com/Jared-Prime/review/pulls/1 by Jared \n good job!"
+          'contents' => "a friend has requested changes on github.com/Jared-Prime/review/pulls/1 by Jared \n good job!"
         )
       end
     end

--- a/spec/review/webhook_spec.rb
+++ b/spec/review/webhook_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Review::Webhook do
       let(:params) do
         { pull_request:
           { html_url: 'github.com/Jared-Prime/review/pulls/1',
-            assignee: { login: 'Jared-Prime' },
+            assignee: { login: 'a friend' },
             user: { login: 'Jared-Prime' } },
           action: 'assigned' }
       end
@@ -48,7 +48,7 @@ RSpec.describe Review::Webhook do
         post '/webhook/github', params
 
         expect(JSON.parse(last_response.body)).to include(
-          'contents' => 'Jared assigned github.com/Jared-Prime/review/pulls/1 to Jared'
+          'contents' => 'Jared assigned github.com/Jared-Prime/review/pulls/1 to a friend'
         )
       end
     end
@@ -59,7 +59,7 @@ RSpec.describe Review::Webhook do
           { html_url: 'github.com/Jared-Prime/review/pulls/1',
             requested_reviewers: [
               { login: 'Jared-Prime' },
-              { login: 'somebody-else' }
+              { login: 'a friend' }
             ],
             user: { login: 'Jared-Prime' } },
           action: 'review_requested' }
@@ -70,7 +70,7 @@ RSpec.describe Review::Webhook do
 
         expect(JSON.parse(last_response.body)).to include(
           include('contents' => 'Jared needs Jared to review github.com/Jared-Prime/review/pulls/1'),
-          include('contents' => 'Jared needs somebody-else to review github.com/Jared-Prime/review/pulls/1')
+          include('contents' => 'Jared needs a friend to review github.com/Jared-Prime/review/pulls/1')
         )
       end
     end
@@ -82,7 +82,7 @@ RSpec.describe Review::Webhook do
             user: { login: 'Jared-Prime' } },
           review: {
             body: 'good job!',
-            user: { login: 'Jared-Prime' }
+            user: { login: 'a friend' }
           },
           action: 'submitted' }
       end
@@ -91,7 +91,7 @@ RSpec.describe Review::Webhook do
         post '/webhook/github', params
 
         expect(JSON.parse(last_response.body)).to include(
-          'contents' => "Jared has reviewed github.com/Jared-Prime/review/pulls/1 by Jared \n good job!"
+          'contents' => "a friend has reviewed github.com/Jared-Prime/review/pulls/1 by Jared \n good job!"
         )
       end
     end


### PR DESCRIPTION
this is more a quirk of the event message sent by Github. In any case,
if it happens that a review submission has the reviewer as the
  requestee, just sent a 400 response

closes #10 