### PR TITLE
change style guide reference to rubocop

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,8 +32,7 @@ some changes or improvements or alternatives.
 Some things that will increase the chance that your pull request is accepted:
 
 * Write tests.
-* Follow our [style guide][style].
+* Commit with a clean rubocop report.
 * Write a [good commit message][commit].
 
-[style]: https://github.com/thoughtbot/guides/tree/master/style
 [commit]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html


### PR DESCRIPTION
## Problem:

I don't really have a style guide.

## Solution:

Just refer to rubocop instead.
