### PR TITLE
Compare silent periods to the number of seconds since midnight

### DIFF
--- a/app/review/alias.rb
+++ b/app/review/alias.rb
@@ -33,16 +33,16 @@ module Review
       private
 
       def too_late?
-        current_hour > silence_start
+        current_time_in_seconds > silence_start
       end
 
       def too_early?
-        current_hour < silence_finish
+        current_time_in_seconds < silence_finish
       end
 
-      def current_hour
+      def current_time_in_seconds
         Time.zone = zone
-        Time.now
+        Time.now.seconds_since_midnight
       end
 
       def zone

--- a/spec/review/alias_spec.rb
+++ b/spec/review/alias_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Review::Alias do
 
     context 'off hours specified in config/settings.yml' do
       before do
-        allow(described_class).to receive(:current_hour) { 64_801 }
+        allow(described_class).to receive(:current_time_in_seconds) { 64_801 }
       end
 
       it 'returns true' do
@@ -18,7 +18,7 @@ RSpec.describe Review::Alias do
 
     context 'on hours specified in config/settings.yml' do
       before do
-        allow(described_class).to receive(:current_hour) { 36_000 }
+        allow(described_class).to receive(:current_time_in_seconds) { 36_000 }
       end
 
       it 'returns false' do
@@ -30,7 +30,7 @@ RSpec.describe Review::Alias do
   describe '.silence?' do
     context 'off hours specified in config/settings.yml' do
       before do
-        allow(described_class).to receive(:current_hour) { 64_801 }
+        allow(described_class).to receive(:current_time_in_seconds) { 64_801 }
       end
 
       it 'returns true' do
@@ -40,7 +40,7 @@ RSpec.describe Review::Alias do
 
     context 'on hours specified in config/settings.yml' do
       before do
-        allow(described_class).to receive(:current_hour) { 36_000 }
+        allow(described_class).to receive(:current_time_in_seconds) { 36_000 }
       end
 
       it 'returns false' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ RSpec.configure do |config|
 
   config.before(:each) do
     allow(HTTParty).to receive(:post)
-    allow(Review::Alias).to receive(:current_hour) { 36_000 }
+    allow(Review::Alias).to receive(:current_time_in_seconds) { 36_000 }
   end
 
   config.after(:each) do


### PR DESCRIPTION
## Problem:

The robit is currently adding a dot to usernames all the time

## Solution:
The start and finish times for silencing mentions are parsed from the settings YAML file, which turns times like `18:00` into a number of seconds.  Instead of comparing the current time directly against those values, compute the number of seconds since midnight for the current time and compare that value to the silencing start and end times.