### PR TITLE
[BUGFIX] use Time.zone.now

### DIFF
--- a/app/review/alias.rb
+++ b/app/review/alias.rb
@@ -42,7 +42,7 @@ module Review
 
       def current_time_in_seconds
         Time.zone = zone
-        Time.now.seconds_since_midnight
+        Time.zone.now.seconds_since_midnight
       end
 
       def zone

--- a/config/aliases.yml
+++ b/config/aliases.yml
@@ -1,0 +1,21 @@
+---
+adomokos: adomokos
+andygeorge: andy
+challeng: jimch
+dbortz: davebortz
+djuber: duber
+ebellis: ed
+Jared-Prime: jared-prime
+jdoss: jdoss
+joeclayallday: joeclayallday
+joeyschoblaska: joey
+michaelphines: michaelphines
+MRoytman: michael
+mstruve: struve
+runningferret: tony
+sbowenwilliams: sean
+shotop: shotop
+thegene: thegene
+timferro: timferro
+jeremy-hanna: jeremy
+tzimizie: byrond

--- a/config/aliases.yml.heroku
+++ b/config/aliases.yml.heroku
@@ -1,0 +1,21 @@
+---
+adomokos: adomokos
+andygeorge: andy
+challeng: jimch
+dbortz: davebortz
+djuber: duber
+ebellis: ed
+Jared-Prime: jared-prime
+jdoss: jdoss
+joeclayallday: joeclayallday
+joeyschoblaska: joey
+michaelphines: michaelphines
+MRoytman: michael
+mstruve: struve
+runningferret: tony
+sbowenwilliams: sean
+shotop: shotop
+thegene: thegene
+timferro: timferro
+jeremy-hanna: jeremy
+tzimizie: byrond

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,5 @@
+---
+silence:
+  zone: America/Chicago
+  start: 18:00
+  end: 08:00 

--- a/config/settings.yml.heroku
+++ b/config/settings.yml.heroku
@@ -1,0 +1,5 @@
+---
+silence:
+  offset: -06:00
+  start: 17:30
+  end: 08:30 


### PR DESCRIPTION
hopefully the last of multiple fixes for #19

## Problem:

The use of `Time.now` continued to report UTC time instead of specified zone, contrary to the expectations for the `Review::Alias.silence?` method.

## Reproduction:

1. Observe that `Review::Alias.silence?` reports incorrectly for your timezone _near the start and end_ times relative to your zone's offsets.

## Solution:
Use `Time.zone.now` to correctly apply the offset.
