### PR TITLE
Make specs time agnostic so that assertions don't fail at night

### DIFF
--- a/spec/review/pull_request_spec.rb
+++ b/spec/review/pull_request_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe Review::PullRequest do
     end
 
     it 'proxies message to Slack' do
-      post '/pr/assign', params
+      Timecop.freeze(Time.parse("2018-07-08 11:14:15")) do
+        post '/pr/assign', params
+      end
 
       expect(JSON.parse(last_response.body)).to include(
         'contents' => 'Jared assigned github.com/Jared-Prime/review/pulls/1 to Jared'
@@ -44,7 +46,9 @@ RSpec.describe Review::PullRequest do
     end
 
     it 'proxies message to Slack' do
-      post '/pr/review/request', params
+      Timecop.freeze(Time.parse("2018-07-08 11:14:15")) do
+        post '/pr/review/request', params
+      end
 
       expect(JSON.parse(last_response.body)).to include(
         'contents' => 'Jared needs somebody-else to review github.com/Jared-Prime/review/pulls/1'
@@ -65,7 +69,9 @@ RSpec.describe Review::PullRequest do
       end
 
       it 'proxies message to Slack' do
-        post '/pr/review/submit', params
+        Timecop.freeze(Time.parse("2018-07-08 11:14:15")) do
+          post '/pr/review/submit', params
+        end
 
         expect(JSON.parse(last_response.body)).to include(
           'contents' => "a friend has reviewed github.com/Jared-Prime/review/pulls/1 by Jared \n good job!"
@@ -86,7 +92,9 @@ RSpec.describe Review::PullRequest do
       end
 
       it 'proxies message to Slack' do
-        post '/pr/review/submit', params
+        Timecop.freeze(Time.parse("2018-07-08 11:14:15")) do
+          post '/pr/review/submit', params
+        end
 
         expect(JSON.parse(last_response.body)).to include(
           'contents' => "a friend has approved github.com/Jared-Prime/review/pulls/1 by Jared \n good job!"
@@ -107,7 +115,9 @@ RSpec.describe Review::PullRequest do
       end
 
       it 'proxies message to Slack' do
-        post '/pr/review/submit', params
+        Timecop.freeze(Time.parse("2018-07-08 11:14:15")) do
+          post '/pr/review/submit', params
+        end
 
         expect(JSON.parse(last_response.body)).to include(
           'contents' => "a friend has requested changes on github.com/Jared-Prime/review/pulls/1 by Jared \n good job!"

--- a/spec/review/pull_request_spec.rb
+++ b/spec/review/pull_request_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Review::PullRequest do
     end
 
     it 'proxies message to Slack' do
-      Timecop.freeze(Time.parse("2018-07-08 11:14:15")) do
+      Timecop.freeze(Time.parse('2018-07-08 11:14:15')) do
         post '/pr/assign', params
       end
 
@@ -46,7 +46,7 @@ RSpec.describe Review::PullRequest do
     end
 
     it 'proxies message to Slack' do
-      Timecop.freeze(Time.parse("2018-07-08 11:14:15")) do
+      Timecop.freeze(Time.parse('2018-07-08 11:14:15')) do
         post '/pr/review/request', params
       end
 
@@ -69,7 +69,7 @@ RSpec.describe Review::PullRequest do
       end
 
       it 'proxies message to Slack' do
-        Timecop.freeze(Time.parse("2018-07-08 11:14:15")) do
+        Timecop.freeze(Time.parse('2018-07-08 11:14:15')) do
           post '/pr/review/submit', params
         end
 
@@ -92,7 +92,7 @@ RSpec.describe Review::PullRequest do
       end
 
       it 'proxies message to Slack' do
-        Timecop.freeze(Time.parse("2018-07-08 11:14:15")) do
+        Timecop.freeze(Time.parse('2018-07-08 11:14:15')) do
           post '/pr/review/submit', params
         end
 
@@ -115,7 +115,7 @@ RSpec.describe Review::PullRequest do
       end
 
       it 'proxies message to Slack' do
-        Timecop.freeze(Time.parse("2018-07-08 11:14:15")) do
+        Timecop.freeze(Time.parse('2018-07-08 11:14:15')) do
           post '/pr/review/submit', params
         end
 

--- a/spec/review/webhook_spec.rb
+++ b/spec/review/webhook_spec.rb
@@ -45,7 +45,9 @@ RSpec.describe Review::Webhook do
       end
 
       it 'delegates through to Slack' do
-        post '/webhook/github', params
+        Timecop.freeze(Time.parse("2018-07-08 11:14:15")) do
+          post '/webhook/github', params
+        end
 
         expect(JSON.parse(last_response.body)).to include(
           'contents' => 'Jared assigned github.com/Jared-Prime/review/pulls/1 to a friend'
@@ -64,7 +66,9 @@ RSpec.describe Review::Webhook do
       end
 
       it 'delegates through to Slack' do
-        post '/webhook/github', params
+        Timecop.freeze(Time.parse("2018-07-08 11:14:15")) do
+          post '/webhook/github', params
+        end
 
         expect(JSON.parse(last_response.body)).to include(
           'contents' => 'Jared needs a friend to review github.com/Jared-Prime/review/pulls/1'
@@ -85,7 +89,9 @@ RSpec.describe Review::Webhook do
       end
 
       it 'proxies message to Slack' do
-        post '/webhook/github', params
+        Timecop.freeze(Time.parse("2018-07-08 11:14:15")) do
+          post '/webhook/github', params
+        end
 
         expect(JSON.parse(last_response.body)).to include(
           'contents' => "a friend has reviewed github.com/Jared-Prime/review/pulls/1 by Jared \n good job!"

--- a/spec/review/webhook_spec.rb
+++ b/spec/review/webhook_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Review::Webhook do
       end
 
       it 'delegates through to Slack' do
-        Timecop.freeze(Time.parse("2018-07-08 11:14:15")) do
+        Timecop.freeze(Time.parse('2018-07-08 11:14:15')) do
           post '/webhook/github', params
         end
 
@@ -66,7 +66,7 @@ RSpec.describe Review::Webhook do
       end
 
       it 'delegates through to Slack' do
-        Timecop.freeze(Time.parse("2018-07-08 11:14:15")) do
+        Timecop.freeze(Time.parse('2018-07-08 11:14:15')) do
           post '/webhook/github', params
         end
 
@@ -89,7 +89,7 @@ RSpec.describe Review::Webhook do
       end
 
       it 'proxies message to Slack' do
-        Timecop.freeze(Time.parse("2018-07-08 11:14:15")) do
+        Timecop.freeze(Time.parse('2018-07-08 11:14:15')) do
           post '/webhook/github', params
         end
 


### PR DESCRIPTION
## Problem:

When specs are run at night, usernames sent to Slack are dotted (ben becomes b.en) which causes assertions on the Slack message to fail.

## Reproduction:

1. Run the spec suite after 5pm

## Solution:

Place API calls inside `Timecop.freeze` blocks to prevent usernames from being dotted.